### PR TITLE
Add integration tests for recompiles.

### DIFF
--- a/src/jasmine-tests/integrationtests/bundler-recompile-spec.js
+++ b/src/jasmine-tests/integrationtests/bundler-recompile-spec.js
@@ -1,0 +1,129 @@
+
+describe("Recompile Tests - ", function() {
+
+    var exec = require('child_process').exec,
+         fs = require('fs'),
+         testHelper = require('./integration-test-helper.js'),
+         testUtility = new testHelper.TestUtility(exec, fs, runs, waitsFor),
+         bundle,
+         bundleContents,
+         testDir = 'recompile-test-suite',
+         runType;
+
+    beforeEach(function () {
+
+        bundleContents = "";
+        testUtility.CreateDirectory(testDir);
+    });
+
+    afterEach(function () {
+        testUtility.CleanDirectory(testDir);
+    });
+
+
+    describe("Javascript: ", function () {
+
+        beforeEach(function () {
+            runType = '.js';
+
+            givenFileToBundle("file1.js", "var foo = 'asdf';");
+            givenFileToBundle("file2.js", "var foo2 = 'bnmf';");
+            givenFileToBundle("mustache1.mustache", "<div>{{a}}</div>");
+
+            bundle();
+
+            verifyBundleIs(';var foo="asdf"\n'
+                         + ';var foo2="bnmf"\n'
+                         + ';window.JST=window.JST||{},JST.mustache1=new Hogan.Template({code:function(a,b,c){var d=this;return d.b(c=c||""),d.b("<div>"),d.b(d.v(d.f("a",a,b,0))),d.b("</div>"),d.fl()},partials:{},subs:{}})\n');
+
+        });
+
+        it("An updated javascript file causes the contents of the bundle to change when re-bundled.", function () {
+
+            givenFileUpdate("file2.js", "var foo2 = 'a new value';");
+
+            bundle();
+
+            verifyBundleIs(';var foo="asdf"\n'
+                         + ';var foo2="a new value"\n'
+                         + ';window.JST=window.JST||{},JST.mustache1=new Hogan.Template({code:function(a,b,c){var d=this;return d.b(c=c||""),d.b("<div>"),d.b(d.v(d.f("a",a,b,0))),d.b("</div>"),d.fl()},partials:{},subs:{}})\n');
+
+        });
+
+        it("An updated mustache file causes the contents of the bundle to change when re-bundled.", function () {
+
+            givenFileUpdate("mustache1.mustache", "<a>{{b}}</a>");
+
+            bundle();
+
+            verifyBundleIs(';var foo="asdf"\n'
+                         + ';var foo2="bnmf"\n'
+                         + ';window.JST=window.JST||{},JST.mustache1=new Hogan.Template({code:function(a,b,c){var d=this;return d.b(c=c||""),d.b("<a>"),d.b(d.v(d.f("b",a,b,0))),d.b("</a>"),d.fl()},partials:{},subs:{}})\n');
+
+        });
+
+    });
+    describe("Css: ", function () {
+
+        beforeEach(function () {
+            runType = '.css';
+
+            givenFileToBundle("file1.css", "style1 { color: red; }");
+            givenFileToBundle("file2.css", "style2 { color: blue; }");
+            givenFileToBundle("less1.less", "@theColor: white; style3 { color: @theColor; }");
+
+            bundle();
+
+            verifyBundleIs('style1{color:red}\n'
+                         + 'style2{color:#00f}\n'
+                         + 'style3{color:#fff}\n');
+
+        });
+
+        it("An updated css file causes the contents of the bundle to change when re-bundled.", function () {
+
+            givenFileUpdate("file1.css", "newstyle1 { color: yellow; }");
+
+            bundle();
+
+            verifyBundleIs('newstyle1{color:#ff0}\n'
+                         + 'style2{color:#00f}\n'
+                         + 'style3{color:#fff}\n');
+        });
+
+        it("An updated less file causes the contents of the bundle to change when re-bundled.", function () {
+
+            givenFileUpdate("less1.less", "@theColor: green; style4 { color: @theColor; }");
+
+            bundle();
+
+            verifyBundleIs('style1{color:red}\n'
+                         + 'style2{color:#00f}\n'
+                         + 'style4{color:green}\n');
+
+        });
+
+    });
+
+
+    var givenFileUpdate = function (fileName, contents) {
+        testUtility.CreateFile(testDir, fileName, contents);
+        testUtility.Wait(1000);
+        testUtility.RunCommandSync("touch " + testDir + "/" + fileName);
+    };
+
+    var verifyBundleIs = function (expectedContents) {
+        testUtility.VerifyFileContents(testDir, "test.min" + runType, expectedContents);
+    };
+
+    var bundle = function () {
+        testUtility.CreateFile(testDir, "test" + runType + ".bundle", bundleContents);
+        testUtility.Bundle(testDir);
+    };
+
+    var givenFileToBundle = function (fileName, contents) {
+        testUtility.CreateFile(testDir, fileName, contents);
+        bundleContents = bundleContents + fileName + "\n";
+    };
+
+});

--- a/src/jasmine-tests/integrationtests/integration-test-helper.js
+++ b/src/jasmine-tests/integrationtests/integration-test-helper.js
@@ -1,0 +1,123 @@
+
+function TestUtility(
+  exec,
+  fs,
+  runs, 
+  waitsFor,
+  logger
+)
+{
+    this.Exec = exec;
+    this.Console = logger || { log: function () { } };
+    this.runFunc = runs;
+    this.waitFunc = waitsFor;
+    this.FileSystem = fs;
+};
+
+exports.TestUtility = TestUtility;
+
+TestUtility.prototype.RunCommandSync = function (cmd, execCallback) {
+    var _this = this,
+        finishedCommand;
+        
+    _this.Console.log('called run command');
+
+    _this.runFunc(function () {
+
+      finishedCommand = false;
+      _this.Console.log('Running command: ' + cmd);
+      _this.Exec(cmd
+            , function(error, stdout, stderr) {
+                (execCallback || function () { })(error, stdout, stderr);
+
+                if (stdout) { _this.Console.log("stdOut: (" + stdout + ")"); }
+                if (stderr) { _this.Console.log("stdErr: (" + stderr + ")"); }
+                if (error) { _this.Console.log("stdErr: (" + error + ")"); }
+
+                finishedCommand = true;
+                _this.Console.log('Finished command: ' + cmd);
+            });        
+   });
+ 
+    _this.waitFunc(function () {
+        return finishedCommand;
+     }, 
+     "Running command did not complete", 
+     750
+  );
+};
+
+TestUtility.prototype.Wait = function (duration) {
+    var _this = this,
+        doneWaiting;
+
+    _this.runFunc(function () {
+
+        finishedCommand = false;
+        _this.Console.log('Waiting for milliseconds: ' + duration);
+        setTimeout(function () {
+                doneWaiting = true;
+            },
+            duration);
+    });
+
+    _this.waitFunc(function () {
+        return doneWaiting;
+    },
+     "Waited longer than 5 seconds.",
+     5000
+  );
+};
+
+TestUtility.prototype.CleanDirectory = function (dir) {
+    var _this = this;
+    _this.runFunc(function () {
+        if (_this.FileSystem.existsSync(dir)) {
+            _this.RunCommandSync("rm -rf ./" + dir);
+        }
+    });
+}
+
+TestUtility.prototype.CreateFile = function (dir, fileName, contents) {
+    var _this = this;
+    _this.runFunc(function () {
+        var fullPath = dir + '/' + fileName;
+
+        var stream = _this.FileSystem.createWriteStream(fullPath, 'utf8');
+        stream.once('open', function (fd) {
+            stream.write(contents);
+            stream.end();
+        });
+    });
+}
+
+TestUtility.prototype.CreateDirectory = function (dir) {
+    var _this = this;
+    _this.runFunc(function () {
+        _this.FileSystem.mkdirSync(dir);
+    });
+}
+
+TestUtility.prototype.ReadFile = function (dir, fileName) {
+    var _this = this;
+    _this.runFunc(function () {
+        return _this.FileSystem.readFileSync(dir + '/' + fileName, 'utf8');
+    });
+}
+
+TestUtility.prototype.VerifyFileContents = function (dir, fileName, expectedContents) {
+    var _this = this;
+    _this.runFunc(function () {
+        var bundleContents = _this.FileSystem.readFileSync(dir + '/' + fileName, 'utf8');
+        expect(bundleContents).toBe(expectedContents);
+    });
+}
+
+TestUtility.prototype.Bundle = function (dir, options) {
+    var _this = this;
+    _this.runFunc(function () {
+        _this.RunCommandSync("node ../bundler.js " + (options || "") + "./" + dir);
+    });
+}
+
+


### PR DESCRIPTION
These tests bundle, modify a file, and verify that another bundle picks
up the change for css, less, js, and mustache files.
