### PR TITLE
Fix gif image parsing

### DIFF
--- a/src/bundle-image-rewrite.js
+++ b/src/bundle-image-rewrite.js
@@ -64,7 +64,7 @@ function BundleImageRewriter(
         return outputRoot + 'version__' + hash + seperator + cleanedUrl;
     }
 
-    this.imageUrlRegex = new RegExp(/url\(.*?g['"]?\)/ig)
+    this.imageUrlRegex = new RegExp(/url\(.*?[gf]['"]?\)/ig)
 }
 
 exports.BundleImageRewriter = BundleImageRewriter;

--- a/src/jasmine-tests/bundle-image-rewrite-spec.js
+++ b/src/jasmine-tests/bundle-image-rewrite-spec.js
@@ -63,7 +63,36 @@ describe("BundleImageRewriter - ", function () {
 
             verifyOutputTextIs(".s { background: url('combined/version__18458d2016656fdb823ed3ef01b8f8da__/img/an-image.jpg') center no-repeat; }");
         });
+		
+		it("Gifs should work.", function () {
 
+			givenImageFile('img/an-image.gif', fileContents1);
+            givenCssFileText("url(img/an-image.gif) url(img/an-image.gif)");
+
+            versionImages();
+
+            verifyOutputTextIs("url('combined/version__18458d2016656fdb823ed3ef01b8f8da__/img/an-image.gif') url('combined/version__18458d2016656fdb823ed3ef01b8f8da__/img/an-image.gif')");
+        });
+
+		it("Pngs should work.", function () {
+
+			givenImageFile('img/an-image.png', fileContents1);
+            givenCssFileText("url(img/an-image.png) url(img/an-image.png)");
+
+            versionImages();
+
+            verifyOutputTextIs("url('combined/version__18458d2016656fdb823ed3ef01b8f8da__/img/an-image.png') url('combined/version__18458d2016656fdb823ed3ef01b8f8da__/img/an-image.png')");
+        });
+
+		it("Jpgs should work.", function () {
+
+			givenImageFile('img/an-image.jpg', fileContents1);
+            givenCssFileText("url(img/an-image.jpg) url(img/an-image.jpg)");
+
+            versionImages();
+
+            verifyOutputTextIs("url('combined/version__18458d2016656fdb823ed3ef01b8f8da__/img/an-image.jpg') url('combined/version__18458d2016656fdb823ed3ef01b8f8da__/img/an-image.jpg')");
+        });
         it("Image urls with double quotes are parsed correctly.", function () {
 
             givenImageFile('img/an-image.jpg', fileContents1);


### PR DESCRIPTION
This allows gifs to be correctly parsed by image versioning.  Previously this would only work for png and jpg files.
