### PR TITLE
Maintain file casing

### DIFF
--- a/src/bundle-files.js
+++ b/src/bundle-files.js
@@ -44,9 +44,7 @@ BundleFiles.prototype.addDirectories = function (file, directoryDictionary) {
     var directories = ['/'];
     var combined = null;
 
-    file = file.toLowerCase();
-
-    var tokens = file.split('/');
+    var tokens = file.toLowerCase().split('/');
     tokens.pop();
 
     tokens.forEach(function (token) {
@@ -142,7 +140,7 @@ BundleFiles.prototype.getBundles = function (fileType) {
 
 BundleFiles.prototype.getFilesInDirectory = function (fileType, bundleDir, currentDir) {
     var _this = this,
-        matcher = fileType == exports.BundleType.Javascript ? _this.jsMatches : _this.cssMatches,
+        matcher = fileType == exports.BundleType.Javascript ? function(name) { return name.isJs(); } : function(name) { return name.isCss(); },
         dictionary = fileType == exports.BundleType.Javascript ? _this._jsDirectories : _this._cssDirectories
         output = [];
 
@@ -158,13 +156,16 @@ BundleFiles.prototype.getFilesInDirectory = function (fileType, bundleDir, curre
 
     files.forEach(function (name) {
 
-        var match = currentDir + '/' + matcher(name, bundleDir, true);
-
-        if (!match.endsWith('#')) {
-            output.push(match);
-        }
+        if(!matcher(name)) {
+ 			return;
+ 		}
+ 	
+        var fileName = currentDir + '/' + name.substring(bundleDir.length + 1);
+ 		output.push(fileName);
     });
 
+	if (output.length == 0) { throw new Error("No files found for directory: " + bundleDir) };
+	
     return output;
 };
 

--- a/src/jasmine-tests/bundle-files-spec.js
+++ b/src/jasmine-tests/bundle-files-spec.js
@@ -153,7 +153,7 @@ describe("BundleFiles.", function () {
                               );
 
           expect(jsFilesInDir.length).toBe(1);
-          expect(jsFilesInDir.contains("output/file.js")).toBe(true);
+          expect(jsFilesInDir.contains("output/File.js")).toBe(true);
       });
 
       it("Ignores trailing slash", function () {
@@ -164,7 +164,7 @@ describe("BundleFiles.", function () {
                               );
 
           expect(jsFilesInDir.length).toBe(1);
-          expect(jsFilesInDir.contains("output/file.js")).toBe(true);
+          expect(jsFilesInDir.contains("output/File.js")).toBe(true);
       });
 
       it("Throws if no files found for directory", function () {
@@ -244,7 +244,7 @@ describe("BundleFiles.", function () {
                               );
 
           expect(cssFilesInDir.length).toBe(1);
-          expect(cssFilesInDir.contains("output/file.css")).toBe(true);
+          expect(cssFilesInDir.contains("output/File.css")).toBe(true);
       });
 
       it("Ignores trailing slash", function () {
@@ -255,7 +255,7 @@ describe("BundleFiles.", function () {
                               );
 
           expect(cssFilesInDir.length).toBe(1);
-          expect(cssFilesInDir.contains("output/file.css")).toBe(true);
+          expect(cssFilesInDir.contains("output/File.css")).toBe(true);
       });
 
       it("Throws if no files found for directory", function () {


### PR DESCRIPTION
This does not matter for most files, but the name of the mustache template in the final JST is based on the file name.  So casing matters in this instance since the js code using the template will expect a certain case.
