### PR TITLE
Clear bundle stats

### DIFF
--- a/src/bundle-stats.js
+++ b/src/bundle-stats.js
@@ -152,9 +152,9 @@ var parseAndAddToCollection = function(bundleName, text, collection, parseRegex,
 var clearCollection = function(name, collection) {
     var bundleShortName = name.split('/').pop();
 
-    if (collection[name])
+    if (collection[bundleShortName])
     {
-        collection[name] = [];
+        collection[bundleShortName] = [];
     }
 };
 

--- a/src/jasmine-tests/bundle-stats/bs-add-localization-file-spec.js
+++ b/src/jasmine-tests/bundle-stats/bs-add-localization-file-spec.js
@@ -91,6 +91,18 @@ describe("BundleStatsCollector - ", function() {
         validateBundle(bundle1, [ ]);
     });
 
+    it("Clearing a bundle at the end of a file path removes all LocalizedStrings.", function () {
+
+        stats.ParseMustacheForStats(bundle1, ls1);
+        stats.ParseMustacheForStats(bundle1, ls2);
+
+        validateBundle(bundle1, [string1, string2]);
+
+        stats.ClearStatsForBundle("file/path/" + bundle1);
+
+        validateBundle(bundle1, []);
+    });
+
 
     it("Duplicate LocalizedStrings are not added.", function() {
 


### PR DESCRIPTION
Fixes a bug with how localized strings are handled.
